### PR TITLE
Prevent IndexError in "latest_five" function

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,1 +1,2 @@
 Shaurya Chawla <emorres25@gmail.com>
+Larry Gray <lwgray@gmail.com>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,1 @@
+Shaurya Chawla <emorres25@gmail.com>

--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ RSS-feed reader
 ## contributing
 1. Fork the repository.
 2. Make corrections.
-3. Edit contributors.txt
+3. Edit AUTHORS.md
 4. Send pull request.

--- a/app.py
+++ b/app.py
@@ -22,6 +22,11 @@ def latest_five():
     d = feedparser.parse(url)
     i = 0
     for i in range(0, 5):
+        # Prevent IndexError if less than five aricles in feed
+        try:
+            d.entries[i]
+        except IndexError:
+            break
         print (Back.CYAN + "\t" + str(i + 1) + "\t")
         print (Back.RED + "Title:") + \
             (Style.RESET_ALL + " " + d.entries[i].title)


### PR DESCRIPTION
Prior to this change, if a feed had less than five articles then
an IndexError would be issued

This change catches the IndexError in "latest_five function" by checking if "i" is out of range 
for "d.entries" and if so then the exception breaks the loop

To see error in original code use url below.  It has only 3 articles
http://igotthegoodstuff.com/feeds/all.atom.xml